### PR TITLE
Add dask futures sum

### DIFF
--- a/futures-sum.ipynb
+++ b/futures-sum.ipynb
@@ -1,0 +1,195 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Futures sum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using dask futures API"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cudf\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import dask\n",
+    "import distributed\n",
+    "import cudf\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dask: /home/nfs/ashwint/miniconda3/envs/cudf_dev_92/lib/python3.7/site-packages/dask/__init__.py\n",
+      "Distributed: /home/nfs/ashwint/miniconda3/envs/cudf_dev_92/lib/python3.7/site-packages/distributed/__init__.py\n",
+      "cuDF: /home/nfs/ashwint/miniconda3/envs/cudf_dev_92/lib/python3.7/site-packages/cudf-0.10.0a0+800.g6407f50-py3.7-linux-x86_64.egg/cudf/__init__.py\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f'Dask: {dask.__file__}')\n",
+    "print(f'Distributed: {distributed.__file__}')\n",
+    "print(f'cuDF: {cudf.__file__}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_env = {\n",
+    "    \"UCX_RNDV_SCHEME\": \"put_zcopy\",\n",
+    "    \"UCX_MEMTYPE_CACHE\": \"n\",\n",
+    "    \"UCX_TLS\": \"rc,cuda_copy,cuda_ipc\",\n",
+    "    \"CUDA_VISIBLE_DEVICES\": \"0,1\",\n",
+    "}\n",
+    "os.environ.update(base_env)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "distributed.scheduler - INFO - Clear task state\n",
+      "distributed.scheduler - INFO -   Scheduler at: ucx://10.33.225.165:51225\n",
+      "distributed.scheduler - INFO -   dashboard at:        10.33.225.165:8789\n",
+      "distributed.nanny - INFO -         Start Nanny at: 'ucx://10.33.225.165:36139'\n",
+      "distributed.nanny - INFO -         Start Nanny at: 'ucx://10.33.225.165:35355'\n",
+      "distributed.scheduler - INFO - Register ucx://10.33.225.165:60453\n",
+      "distributed.scheduler - INFO - Starting worker compute stream, ucx://10.33.225.165:60453\n",
+      "distributed.core - INFO - Starting established connection\n",
+      "distributed.scheduler - INFO - Register ucx://10.33.225.165:52940\n",
+      "distributed.scheduler - INFO - Starting worker compute stream, ucx://10.33.225.165:52940\n",
+      "distributed.core - INFO - Starting established connection\n",
+      "distributed.scheduler - INFO - Receive client connection: Client-65ab2836-c925-11e9-9289-d8c49764f624\n",
+      "distributed.core - INFO - Starting established connection\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"border: 2px solid white;\">\n",
+       "<tr>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Client</h3>\n",
+       "<ul style=\"text-align: left; list-style: none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Scheduler: </b>ucx://10.33.225.165:51225</li>\n",
+       "  <li><b>Dashboard: </b><a href='http://10.33.225.165:8789/status' target='_blank'>http://10.33.225.165:8789/status</a>\n",
+       "</ul>\n",
+       "</td>\n",
+       "<td style=\"vertical-align: top; border: 0px solid white\">\n",
+       "<h3 style=\"text-align: left;\">Cluster</h3>\n",
+       "<ul style=\"text-align: left; list-style:none; margin: 0; padding: 0;\">\n",
+       "  <li><b>Workers: </b>2</li>\n",
+       "  <li><b>Cores: </b>2</li>\n",
+       "  <li><b>Memory: </b>270.53 GB</li>\n",
+       "</ul>\n",
+       "</td>\n",
+       "</tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Client: scheduler='ucx://10.33.225.165:51225' processes=2 cores=2>"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from dask.distributed import Client, wait\n",
+    "from dask_cuda import DGX\n",
+    "\n",
+    "cluster = DGX(CUDA_VISIBLE_DEVICES=[0,1], \n",
+    "              dashboard_address='10.33.227.165:8789')\n",
+    "client = Client(cluster)\n",
+    "# client = Client('ucx://10.33.225.165:42841')\n",
+    "client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dask.distributed import wait\n",
+    "import operator\n",
+    "\n",
+    "\n",
+    "left = client.map(lambda x: cudf.Series([x]), range(100), workers=[0])\n",
+    "right = client.map(lambda x: cudf.Series([x]), range(100), workers=[1])\n",
+    "added = client.map(operator.add, left, right)\n",
+    "wait(added)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This test uses Dask's Futures API to directly operate on `cudf.Series` objects rather than via dask dataframes as previous tests have done. 